### PR TITLE
Run Playwright Firefox in headful mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ units sold last month
 lines of code
 
 Adjust CSS selectors (select_one, select) according to the actual HTML structure after inspecting the Odoo pages in a browser.
+
+## Running with Docker
+To run the scraper in a container with the Firefox GUI visible, ensure that the
+container has access to your host display. A typical invocation looks like:
+
+```
+docker run --rm -it --ipc=host -e DISPLAY=$DISPLAY \
+    -v /tmp/.X11-unix:/tmp/.X11-unix odoo-store-scraper
+```
+
+The `--ipc=host` flag prevents shared memory issues and allows Playwright to
+launch the browser in headful mode.

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -41,8 +41,9 @@ def get_lines_of_code(app_url: str, context) -> str:
 
 def scrape_all_apps() -> pd.DataFrame:
     records = []
-    with sync_playwright() as p:
-        browser = p.firefox.launch(headless=False)
+    # Launch Firefox in headful mode for visual debugging
+    with sync_playwright() as playwright:
+        browser = playwright.firefox.launch(headless=False)
         context = browser.new_context()
         page = context.new_page()
 
@@ -50,6 +51,9 @@ def scrape_all_apps() -> pd.DataFrame:
 
         for current_page in range(1, total_pages + 1):
             page.goto(BASE_URL.format(page=current_page))
+            # Capture a screenshot on the first page to verify visibility
+            if current_page == 1:
+                page.screenshot(path="page1.png")
             cards = page.locator("div.card.app")
             count = cards.count()
 


### PR DESCRIPTION
## Summary
- Launch Firefox in headful mode and capture a screenshot on the first page
- Document Docker run options for displaying the browser UI

## Testing
- `pytest`
