### PR TITLE
feat: stream results to csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Execute the scraper:
 make run
 ```
 
-The output is a pandas DataFrame printed to stdout with columns:
+While running, a file `scraped_apps.csv` is updated after each page so you can
+inspect progress live. The script still prints the final pandas DataFrame to
+stdout with columns:
 
 - app name
 - app description

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from playwright.sync_api import sync_playwright
 from tqdm import tqdm
@@ -43,13 +44,19 @@ def get_lines_of_code(app_url: str, context) -> str:
     page.close()
     return lines_of_code
 
-def scrape_all_apps(headless: bool = True) -> pd.DataFrame:
+def scrape_all_apps(headless: bool = True, csv_path: str = "scraped_apps.csv") -> pd.DataFrame:
     """Scrape summary information for all paid apps.
 
     Args:
         headless: Whether to run the browser in headless mode.
+        csv_path: Path where results are incrementally written.
     """
-    records = []
+    records: list[dict] = []
+
+    # Start with a fresh file each run
+    if os.path.exists(csv_path):
+        os.remove(csv_path)
+
     # Launch Firefox in headless mode for environments without a display
     with sync_playwright() as playwright:
         browser = playwright.firefox.launch(headless=headless)
@@ -68,6 +75,7 @@ def scrape_all_apps(headless: bool = True) -> pd.DataFrame:
                 cards = page.locator("div.card.app")
                 count = cards.count()
 
+                page_records: list[dict] = []
                 for i in range(count):
                     card = cards.nth(i)
                     info = parse_app_summary(card)
@@ -75,6 +83,16 @@ def scrape_all_apps(headless: bool = True) -> pd.DataFrame:
                         info["app url"], context
                     )
                     records.append(info)
+                    page_records.append(info)
+
+                df_page = pd.DataFrame(page_records)
+                file_exists = os.path.exists(csv_path)
+                df_page.to_csv(
+                    csv_path,
+                    mode="a",
+                    index=False,
+                    header=not file_exists,
+                )
 
                 pbar.update(1)
 


### PR DESCRIPTION
## Summary
- stream scraped app data to `scraped_apps.csv` as each page is processed
- document live CSV output in README

## Testing
- `python -m py_compile scraper/main.py`
- `pytest -q`
