### PR TITLE
Improve navigation resilience

### DIFF
--- a/scraper/main.py
+++ b/scraper/main.py
@@ -1,11 +1,18 @@
+import time
+import logging
+
 import pandas as pd
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import TimeoutError, sync_playwright
 from tqdm import tqdm
 
 BASE_URL = (
     "https://apps.odoo.com/apps/modules/browse/"
     "page/{page}?price=Paid&order=Purchases"
 )
+
+DEFAULT_NAVIGATION_TIMEOUT_MS = 60_000
+MAX_NAVIGATION_RETRIES = 3
+RETRY_DELAY_SECONDS = 5
 
 def get_total_pages(page) -> int:
     """Fetch first page and read pagination for total page count."""
@@ -35,6 +42,7 @@ def parse_app_summary(card) -> dict:
 def get_lines_of_code(app_url: str, context) -> str:
     """Visit app detail page and scrape lines-of-code metric."""
     page = context.new_page()
+    page.set_default_navigation_timeout(DEFAULT_NAVIGATION_TIMEOUT_MS)
     page.goto(app_url)
     loc_tag = page.locator("span:has-text('Lines of Code')")
     lines_of_code = (
@@ -56,12 +64,26 @@ def scrape_all_apps(headless: bool = True) -> pd.DataFrame:
         # Ignore HTTPS certificate issues that may appear in automated environments
         context = browser.new_context(ignore_https_errors=True)
         page = context.new_page()
+        page.set_default_navigation_timeout(DEFAULT_NAVIGATION_TIMEOUT_MS)
 
         total_pages = get_total_pages(page)
 
         with tqdm(total=total_pages, desc="Scraping pages") as pbar:
             for current_page in range(1, total_pages + 1):
-                page.goto(BASE_URL.format(page=current_page))
+                for _ in range(MAX_NAVIGATION_RETRIES):
+                    try:
+                        page.goto(BASE_URL.format(page=current_page))
+                        break
+                    except TimeoutError:
+                        time.sleep(RETRY_DELAY_SECONDS)
+                else:
+                    logging.warning(
+                        "Failed to load page %s after %s attempts. Skipping.",
+                        current_page,
+                        MAX_NAVIGATION_RETRIES,
+                    )
+                    pbar.update(1)
+                    continue
                 # Capture a screenshot on the first page to verify visibility
                 if current_page == 1:
                     page.screenshot(path="page1.png")


### PR DESCRIPTION
## Summary
- centralize navigation timeout and retry configuration
- add 60-second default navigation timeout for catalog and detail pages
- retry catalog navigation up to three times before warning and skipping
- log a warning when navigation repeatedly fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbcf070070832ca171b659c1900070