### PR TITLE
Add Docker support and configurable scraper options

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.venv
+__pycache__
+*.pyc
+scraped_apps.csv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/playwright/python:v1.45.2-jammy
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt && playwright install firefox
+
+COPY scraper ./scraper
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "scraper/main.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 VENV ?= .venv
 PYTHON := $(VENV)/bin/python
 PLAYWRIGHT := $(VENV)/bin/playwright
+IMAGE ?= odoo-store-scraper
 
-.PHONY: venv clean run
+.PHONY: venv clean run docker-build docker-run
 
 venv: $(PYTHON)
 
@@ -16,4 +17,10 @@ clean:
 	rm -rf $(VENV)
 
 run: $(PYTHON)
-	$(PYTHON) scraper/main.py
+        $(PYTHON) scraper/main.py
+
+docker-build:
+        docker build -t $(IMAGE) .
+
+docker-run:
+        docker run --rm -v $(PWD):/data -e CSV_PATH=/data/scraped_apps.csv $(IMAGE)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ stdout with columns:
 
 Adjust CSS selectors (`select_one`, `select`) according to the actual HTML structure after inspecting the Odoo pages in a browser.
 
+## Docker
+
+Build the image:
+
+```
+make docker-build
+```
+
+Run the scraper in a container, writing results to `scraped_apps.csv` in the current directory:
+
+```
+make docker-run
+```
+
+You can customize the behavior with environment variables. For example, to run with a visible browser and save to a different file:
+
+```
+docker run --rm -e HEADLESS=0 -e CSV_PATH=/data/apps.csv -v $(pwd):/data odoo-store-scraper
+```
+
 ## Cleanup
 
 Remove the virtual environment:

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -123,7 +123,9 @@ def scrape_all_apps(headless: bool = True, csv_path: str = "scraped_apps.csv") -
     return pd.DataFrame(records)
 
 def main():
-    df = scrape_all_apps()
+    headless = os.environ.get("HEADLESS", "1") != "0"
+    csv_path = os.environ.get("CSV_PATH", "scraped_apps.csv")
+    df = scrape_all_apps(headless=headless, csv_path=csv_path)
     print(df)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a Dockerfile based on Playwright image to containerize the scraper
- allow setting `HEADLESS` and `CSV_PATH` env vars for flexible runs
- expand Makefile with docker targets and document usage in README

## Testing
- `python -m py_compile scraper/main.py`
- `docker build -t odoo-store-scraper .` *(fails: command not found)*

