### PR TITLE
Add output volume and CSV path configuration to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM mcr.microsoft.com/playwright/python:v1.55.0-jammy
 
 WORKDIR /app
+VOLUME ["/data"]
+ENV CSV_PATH=/data/scraped_apps.csv
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && playwright install firefox


### PR DESCRIPTION
## Summary
- Mount /data volume in container
- Set CSV_PATH environment variable to /data/scraped_apps.csv for scraper output

## Testing
- `docker build -t odoo-scraper .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `docker run -v "$(pwd)":/data odoo-scraper` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf00d83c0832c91b87b76d13cb9f0